### PR TITLE
FCTraining_patch

### DIFF
--- a/frontend/src/Pages/Guide/guides/fctraining/guide.md
+++ b/frontend/src/Pages/Guide/guides/fctraining/guide.md
@@ -2,12 +2,12 @@
 
 ## Tryouts
 
-TDF is always looking for some new FC's!
+TDF is always looking for new FC's.
 Is fleet down during your prime time? Want to fix that?
 
-There is no pressure to accept a T badge straight away. You can ask to voice and/or tag a few fleets, see if it's for you. All thats required is an L badge! You can ask any full FC to do a tryout, you can do up to five tryouts. All you need to know before starting a tryout is on this page, tagging order and shortcuts. You don't need to have tags completely memorized for first fleet!
+There is no pressure to accept a T badge straight away. You can ask to voice and/or tag a few fleets, see if it's for you. All thats required is an L badge! You can ask any full FC to do a tryout, you can do up to five tryouts. All you need to know before starting a tryout is on this page, tagging order and shortcuts. You don't need to have tags completely memorized for the first fleet.
 
-If you have any doubts or questions, ask any FC, FC Trainer or council !
+If you have any doubts or questions, ask any FC, FC Trainer or council.
 
 ## Joining the training program
 
@@ -32,24 +32,24 @@ To officially join the training program you need an **L tag** and a fully skille
 
 In this first stage you will learn how to voice fleet, tag and do waitlist invites/motd updates. You will be expected to learn and know every role and anchor position.
 
-Progressing to the next stage requires passing **VAN FLEET** (yes seriously), It's a backseat with an FC Trainer, you will do invites trough ingame channel waitlist so make sure you know all the fits !
+Progressing to the next stage requires passing **VAN FLEET** (yes seriously), It's a backseat with an FC Trainer, you will do invites trough the in game waitlist channel, so make sure you know all the fits.
 
 ### Advanced Trainee
 
-In this stage efficiency, safety and in depth knowledge will be trained and expected. You will need to master contesting, knowing how the agro mechanics work. Knowing NPC's and why we tag them the way we do. Fleet control will also need to be mastered.
+In this stage, efficiency, safety and in depth knowledge will be taught and expected. You will need to master contesting, knowing how the agro mechanics work. Knowing NPC's and why we tag them the way we do. Fleet control will also need to be mastered.
 
 Progressing to the next stage requires passing **BUS FLEET** along with getting at least one other +1 from any FC Trainer or council.
 
-### Probitionary FC
+### Probationary FC
 
-Fc's that just got tagged, they need 6 logi and cannot train nestors or new FC's. The Probitionary period can last up to 3 months.
+FC's that just got their HQ tags, they need 6 logi and cannot train nestors or new FC's. The Probationary period can last up to 3 months.
 
 ## Tagging
 
 You can have this open on your phone in your tryouts and/or first trainee fleets.
 Make sure to set shortcuts for tagging, you need the sequencers 1 - 9 and A - I, a seperate shortcut for X tag and a shortcut for broadcast align. **Some of these tags can be done differently, you will learn what you prefer while FCing.**
 
-**The scrams are TOADS** : Tama, Outuni, Auga, Deltole, Schmael
+**The scrams are TOADS** : Tama, Outuni, Auga, Deltole, Schmaeel
 
 **N : Numbers**
 **L : Letters**


### PR DESCRIPTION
General tidying of the wording/punctuation for FC training guide. Removed the excessive use of ! and spaces.