### PR TITLE
Logi starter renamed to required in skill page

### DIFF
--- a/frontend/src/Components/SkillDisplay.js
+++ b/frontend/src/Components/SkillDisplay.js
@@ -157,6 +157,8 @@ export function SkillList({ mySkills, shipName, filterMin }) {
   );
 }
 
+export function Legend() {}
+
 export function SkillDisplay({ characterId, ship, setShip = null, filterMin = false }) {
   const [skills] = useApi(`/api/skills?character_id=${characterId}`);
 
@@ -199,10 +201,19 @@ export function SkillDisplay({ characterId, ship, setShip = null, filterMin = fa
           </InputGroup>
         </Buttons>
       )}
-      <div style={{ marginBottom: "1em" }}>
-        Legend: <Badge variant="danger">Starter</Badge> <Badge variant="warning">Basic</Badge>{" "}
-        <Badge variant="secondary">Elite</Badge> <Badge variant="success">Elite GOLD</Badge>
-      </div>
+
+      {ship === "Nestor" || ship === "Guardian" || ship === "Oneiros" ? (
+        <div style={{ marginBottom: "1em" }}>
+          Legend: <Badge variant="danger">Required</Badge> <Badge variant="warning">Basic</Badge>{" "}
+          <Badge variant="secondary">Elite</Badge> <Badge variant="success">Elite GOLD</Badge>
+        </div>
+      ) : (
+        <div style={{ marginBottom: "1em" }}>
+          Legend: <Badge variant="danger">Starter</Badge> <Badge variant="warning">Basic</Badge>{" "}
+          <Badge variant="secondary">Elite</Badge> <Badge variant="success">Elite GOLD</Badge>
+        </div>
+      )}
+
       {skills ? (
         <SkillList mySkills={skills} shipName={ship} filterMin={filterMin} />
       ) : (

--- a/frontend/src/Pages/Guide/guides/newbro/guide.md
+++ b/frontend/src/Pages/Guide/guides/newbro/guide.md
@@ -12,7 +12,7 @@ To get started in TDF all you need is to be able to **fully online your ship**, 
 
 EM-806 Implant is required for all Nestors & Guardians.
 
-**Basic tier skills are a minimum** You also need to be able to fully online your ship.
+**Basic tier skills are a minimum**, you also need to be able to fully online your ship.
 
 - Exception: **TDF_ONI_HQ_STARTER_LOGI4** (Sensor Linking 3, Logistics Cruiser 4 Allowed)
 

--- a/frontend/src/Pages/Guide/guides/newbro/guide.md
+++ b/frontend/src/Pages/Guide/guides/newbro/guide.md
@@ -2,6 +2,8 @@
 
 ## Requirements
 
+TDF uses a progress system Starter, Basic, Elite, Elite Gold are the different tiers you can achieve on your ship specific skills. You can see your current status for each ship on the skill page. The target level displayed for each skill is what is required to reach the next tier.
+
 ### DPS
 
 To get started in TDF all you need is to be able to **fully online your ship**, and have the **four armor compensation skills at level 2** for starter fits, 4+ for any other fits. The **basic skills** are the skills you should focus on when you start flying. As long as you still have skills at the starter level and are using a starter fit you will be placed in the starter squad, which is limited to 4 - 5 in fleet.
@@ -10,7 +12,7 @@ To get started in TDF all you need is to be able to **fully online your ship**, 
 
 EM-806 Implant is required for all Nestors & Guardians.
 
-**Basic skills are a minimum** you can not have any starter level skills. You need to be able to fully online your ship.
+**Basic tier skills are a minimum** You also need to be able to fully online your ship.
 
 - Exception: **TDF_ONI_HQ_STARTER_LOGI4** (Sensor Linking 3, Logistics Cruiser 4 Allowed)
 

--- a/frontend/src/Pages/Guide/guides/upgrade/guide.md
+++ b/frontend/src/Pages/Guide/guides/upgrade/guide.md
@@ -6,7 +6,7 @@ We expect all pilots to upgrade their primary ship to Elite in a reasonable amou
 
 We have hard upper bounds for the time you can spend in fleet while upgrading, but don’t treat these as targets. Upgrade as soon as you reasonably can, and you will stay well within the limits.
 
-All pilots are required to be out of the Starter squad by 50 hours of fleet time and be in an advanced fit (or higher) by 100 hours. By 150 hours you must be elite, though bastion-fitted marauders get 250 hours for this.
+**All pilots are required to be out of the Starter squad by 50 hours of fleet time and be in an advanced fit (or higher) by 100 hours. By 150 hours you must be elite. Bastion-fitted marauders have 250 hours.**
 
 TDF works with a tier system. Pilots can be categorized as starter, basic, elite and elite gold. See upgrade guidance as per below:
 

--- a/frontend/src/Pages/Guide/guides/xup/guide.md
+++ b/frontend/src/Pages/Guide/guides/xup/guide.md
@@ -2,7 +2,7 @@
 
 ## Joining a TDF fleet
 
-When the MOTD states that fleet is running, x-up on the [TDF WAITLIST](/) with your ship fitting, Join voice comms; [Teamspeak 3](https://www.teamspeak.com/en/) (server details are in **TDF-Official** MOTD in game) make sure you are no more than 2 jumps out when you x-up and wait for fleet invite. If you are more than 2 jumps out you will be dropped from the fleet!
+When the MOTD states that fleet is running, x-up on the [TDF WAITLIST](/waitlist?wl=1) (requires login) with your ship fitting, Join voice comms; [Teamspeak 3](https://www.teamspeak.com/en/) (server details are in **TDF-Official** MOTD in game) make sure you are no more than 2 jumps out when you x-up and wait for fleet invite. If you are more than 2 jumps out you will be dropped from the fleet!
 
 ## Using the Waitlist
 


### PR DESCRIPTION
When clicking on oni/nestor/guard the legend changes starter to required to make it more clear/differentiate from DPS.