### PR TITLE
Skills electronic warfare patch

### DIFF
--- a/backend/data/skills.yaml
+++ b/backend/data/skills.yaml
@@ -170,6 +170,7 @@ requirements:
       min: 3
       elite: 4
     Electronic Warfare:
+      elite: 4
       gold: 4
     Thermodynamics:
       min: 3


### PR DESCRIPTION
Fix for the electronic warefare skill display being elite at any level below 4, skill should be basic until at 4 as a pre req for adv drone avionics.