### PR TITLE
Update modules.yaml

### DIFF
--- a/backend/data/modules.yaml
+++ b/backend/data/modules.yaml
@@ -51,6 +51,9 @@ alternatives:
   - - Ogre II
   - - "'Augmented' Ogre"
 
+- - - Large Explosive Armor Reinforcer I
+  - - Large Explosive Armor Reinforcer II
+
 from_meta: # Automagically determine alternatives
 - base: Sensor Booster II
 - base: Tracking Computer II
@@ -129,8 +132,6 @@ identification: # Modules/groups we use to look at to figure out what we're flyi
 - Damage Control II
 - 1600mm Steel Plates II
 - Multispectrum Energized Membrane II
-- Large Explosive Armor Reinforcer I
-- Large Explosive Armor Reinforcer II
 - Large EM Armor Reinforcer I
 - Large Thermal Armor Reinforcer I
 - Large Kinetic Armor Reinforcer I


### PR DESCRIPTION
The new armor rig changes confuses the waitlist when you x-up with T2 Explo Rigs on Advanced Vindi.
This change avoids that and marks Advanced or Lower Vindi fits as green if they upgrade from T1 Explo to T2