### PR TITLE
Skill plans Only fetch the size we need

### DIFF
--- a/frontend/src/Pages/Skills/Plans.js
+++ b/frontend/src/Pages/Skills/Plans.js
@@ -83,7 +83,7 @@ function ShowPlan({ plan, mySkills }) {
             {plan.ships.map((ship) => (
               <img
                 key={ship.id}
-                src={`https://images.evetech.net/types/${ship.id}/render?size=256`}
+                src={`https://images.evetech.net/types/${ship.id}/render?size=128`}
                 style={{ maxWidth: "128px", margin: "0.5em" }}
                 alt={ship.name}
                 title={ship.name}

--- a/frontend/src/Pages/Skills/Plans.js
+++ b/frontend/src/Pages/Skills/Plans.js
@@ -158,7 +158,7 @@ function PlanList({ plans, mySkills }) {
                   {plan.ships.map((ship) => (
                     <img
                       key={ship.id}
-                      src={`https://images.evetech.net/types/${ship.id}/render?size=128`}
+                      src={`https://images.evetech.net/types/${ship.id}/render?size=64`}
                       alt={ship.name}
                       title={ship.name}
                     />


### PR DESCRIPTION
We shouldn't fetch a 256px image and then display it as 128px.
Or Fetch 128px but then only use 64px