### PR TITLE
Alt lives matters

### DIFF
--- a/backend/src/core/fleet_updater.rs
+++ b/backend/src/core/fleet_updater.rs
@@ -154,7 +154,7 @@ impl FleetUpdater {
                         .await?;
                     } else {
                         sqlx::query!(
-                            "DELETE FROM waitlist_entry_fit WHERE entry_id=?",
+                            "DELETE FROM waitlist_entry_fit WHERE entry_id=? AND is_alt = 0",
                             record.entry_id
                         )
                         .execute(&mut tx)

--- a/backend/src/routes/waitlist/xup.rs
+++ b/backend/src/routes/waitlist/xup.rs
@@ -245,13 +245,18 @@ async fn xup_multi(
         let implant_set_id = dedup_implants(&mut tx, this_pilot_data.implants).await?;
 
         // Delete existing X'up for the hull
-        if is_alt > 0 {
-            sqlx::query!("DELETE FROM waitlist_entry_fit WHERE character_id = ? AND hull = ? AND is_alt = 1",character_id, fit.hull).fetch_optional(&mut tx).await?;
+        if is_alt {
+            if let Some(existing_x) = sqlx::query!("
+            SELECT waitlist_entry_fit.id FROM waitlist_entry_fit JOIN fitting ON fit_id=fitting.id WHERE character_id = ? AND hull = ? AND is_alt = 1
+            ",character_id, fit.hull).fetch_optional(&mut tx).await? {
+                sqlx::query!("DELETE FROM waitlist_entry_fit WHERE id = ?", existing_x.id).execute(&mut tx).await?;
+            }
         } else { 
             if let Some(existing_x) = sqlx::query!("
             SELECT waitlist_entry_fit.id FROM waitlist_entry_fit JOIN fitting ON fit_id=fitting.id WHERE entry_id = ? AND hull = ? AND is_alt = 0
-        ", entry_id, fit.hull).fetch_optional(&mut tx).await? {
-            sqlx::query!("DELETE FROM waitlist_entry_fit WHERE id = ?", existing_x.id).execute(&mut tx).await?;
+            ", entry_id, fit.hull).fetch_optional(&mut tx).await? {
+                sqlx::query!("DELETE FROM waitlist_entry_fit WHERE id = ?", existing_x.id).execute(&mut tx).await?;
+            }
         }
 
         let fit_checked = tdf::fitcheck::FitChecker::check(this_pilot_data, &fit)?;

--- a/backend/src/routes/waitlist/xup.rs
+++ b/backend/src/routes/waitlist/xup.rs
@@ -245,8 +245,11 @@ async fn xup_multi(
         let implant_set_id = dedup_implants(&mut tx, this_pilot_data.implants).await?;
 
         // Delete existing X'up for the hull
-        if let Some(existing_x) = sqlx::query!("
-            SELECT waitlist_entry_fit.id FROM waitlist_entry_fit JOIN fitting ON fit_id=fitting.id WHERE entry_id = ? AND hull = ?
+        if is_alt > 0 {
+            sqlx::query!("DELETE FROM waitlist_entry_fit WHERE character_id = ? AND hull = ? AND is_alt = 1",character_id, fit.hull).fetch_optional(&mut tx).await?;
+        } else { 
+            if let Some(existing_x) = sqlx::query!("
+            SELECT waitlist_entry_fit.id FROM waitlist_entry_fit JOIN fitting ON fit_id=fitting.id WHERE entry_id = ? AND hull = ? AND is_alt = 0
         ", entry_id, fit.hull).fetch_optional(&mut tx).await? {
             sqlx::query!("DELETE FROM waitlist_entry_fit WHERE id = ?", existing_x.id).execute(&mut tx).await?;
         }


### PR DESCRIPTION
This will keep remaining alts on the waitlist after you invite one of them and allow you to x-up multiple alts with the same hull.

PS. You may need to recreate the waitlist_entry table or atleast make sure it doesn't have an is_alt column.