### PR TITLE
Skill plan revamp mar22 ascendancy patch

### DIFF
--- a/backend/data/skillplan.yaml
+++ b/backend/data/skillplan.yaml
@@ -1,8 +1,8 @@
 plans:
 
-- name: TDF_VINDI_BASIC
+- name: VINDICATOR BASIC PATH
   description: >
-    MEGA > VINDI_STARTER > VINDI_BASIC: This skill plan will train you from starter Megathron in to the basic Vindi fit, this will get you out of starter queue.
+    This skill plan will train you from starter Megathron in to the basic Vindi fit, this will get you out of starter queue.
   plan:
   - type: tank
     from: starter
@@ -21,9 +21,9 @@ plans:
     from: Vindicator
     tier: min
 
-- name: TDF_NIGHTMARE_BASIC
+- name: NIGHTMARE BASIC PATH
   description: >
-    MEGA > NM_STARTER > NM_BASIC: This skill plan will train you from starter Megathron in to the basic Nightmare fit, this will get you out of starter queue.
+    This skill plan will train you from starter Megathron in to the basic Nightmare fit, this will get you out of starter queue.
   plan:
   - type: tank
     from: starter
@@ -42,9 +42,9 @@ plans:
     from: Nightmare
     tier: min
 
-- name: TDF_VINDI_ELITE
+- name: VINDICATOR ELITE PATH
   description: >
-    MEGA > VINDI_STARTER > VINDI_BASIC > VINDI_ADVANCED > VINDI_ELITE: This skill plan will train you from starter Megathron through to the elite Vindi fit.
+    This skill plan will train you from starter Megathron through to the elite Vindi fits.
   plan:
   - type: tank
     from: starter
@@ -62,19 +62,25 @@ plans:
   - type: skills
     from: Vindicator
     tier: min
+  - type: fit
+    hull: Vindicator
+    fit: TDF_VINDI_ADVANCED
   - type: skill
     from: Cybernetics
-    level: 4
+    level: 5
   - type: fit
     hull: Vindicator
     fit: TDF_VINDI_ELITE_HYBRID
+  - type: fit
+    hull: Vindicator
+    fit: TDF_VINDI_ELITE
   - type: skills
     from: Vindicator
     tier: elite
 
-- name: TDF_KRONOS_ELITE
+- name: KRONOS ELITE PATH
   description: >
-    MEGA > VINDI_BASIC > VINDI_ADVANCED > KRONOS_ELITE: This skill plan will train you from starter Megathron through to the elite Kronos fit.
+    This skill plan will train you from starter Megathron through to the Vindicator and finally onto elite Kronos fits.
   plan:
   - type: tank
     from: starter
@@ -92,24 +98,25 @@ plans:
   - type: skills
     from: Vindicator
     tier: min
-  - type: tank
-    from: bastion
-  - type: skill
-    from: Cybernetics
-    level: 4
   - type: skills
     from: Kronos
     tier: min
   - type: fit
     hull: Kronos
-    fit: TDF_KRONOS_ELITE_HYBRID
+    fit: TDF_KRONOS_ADVANCED
+  - type: skill
+    from: Cybernetics
+    level: 5
+  - type: fit
+    hull: Kronos
+    fit: TDF_KRONOS_ELITE
   - type: skills
     from: Kronos
     tier: elite
 
-- name: TDF_PALADIN_ELITE
+- name: PALADIN ELITE PATH
   description: >
-    MEGA > NM_STARTER > NM_BASIC > NM_ADVANCED > PALLY_ELITE: This skill plan will train you from starter Megathron through to the elite Paladin fit.
+    This skill plan will train you from starter Megathron through to the Nightmare and finally onto the elite Paladin fits.
   plan:
   - type: tank
     from: starter
@@ -127,77 +134,118 @@ plans:
   - type: skills
     from: Nightmare
     tier: min
-  - type: tank
-    from: bastion
-  - type: skill
-    from: Cybernetics
-    level: 4
-  - type: skills
-    from: Paladin
-    tier: min
-  - type: fit
-    hull: Paladin
-    fit: TDF_PALLY_ELITE_HYBRID
-  - type: skills
-    from: Paladin
-    tier: elite
-
-- name: TDF_PALADIN_ELITE v2
-  description: >
-    PALLY_ADVANCED > PALLY_ELITE: This skill plan will train you from advanced Paladin through to the elite Paladin fit.
-  plan:
   - type: skills
     from: Paladin
     tier: min
   - type: fit
     hull: Paladin
     fit: TDF_PALLY_ADVANCED
-  - type: tank
-    from: bastion
   - type: skill
     from: Cybernetics
-    level: 4
+    level: 5
   - type: fit
     hull: Paladin
-    fit: TDF_PALLY_ELITE_HYBRID
+    fit: TDF_PALLY_ELITE
   - type: skills
     from: Paladin
     tier: elite
 
+- name: PALADIN ONLY PATH 
+  description: >
+    This skill plan will train you from advanced Paladin through to the elite Paladin fits.
+  plan:
+  - type: tank
+    from: min
+  - type: skills
+    from: Paladin
+    tier: min
+  - type: fit
+    hull: Paladin
+    fit: TDF_PALLY_ADVANCED
+  - type: skill
+    from: Cybernetics
+    level: 5
+  - type: fit
+    hull: Paladin
+    fit: TDF_PALLY_ELITE
+  - type: skills
+    from: Paladin
+    tier: elite
+
+- name: KRONOS ONLY PATH 
+  description: >
+    This skill plan will train you from advanced Kronos through to the elite Kronos fits.
+  plan:
+  - type: tank
+    from: min
+  - type: skills
+    from: Kronos
+    tier: min
+  - type: fit
+    hull: Kronos
+    fit: TDF_KRONOS_ADVANCED
+  - type: skill
+    from: Cybernetics
+    level: 5
+  - type: fit
+    hull: Kronos
+    fit: TDF_KRONOS_ELITE
+  - type: skills
+    from: Kronos
+    tier: elite
+
 - name: VINDICATOR ELITE
   description: >
-    Elite skills Vindi plan, simple.
+    This skill plan only trains the requirements for elite Vindicator fits.
   plan:
+  - type: tank
+    from: min
+  - type: skill
+    from: Cybernetics
+    level: 5
   - type: fit
     hull: Vindicator
     fit: TDF_VINDI_ELITE_HYBRID
+  - type: fit
+    hull: Vindicator
+    fit: TDF_VINDI_ELITE
   - type: skills
     from: Vindicator
     tier: elite
 
 - name: KRONOS ELITE
   description: >
-    Elite skills Kronos plan, simple.
+    This skill plan only trains the requirements for elite Kronos fits.
   plan:
+  - type: tank
+    from: min
+  - type: skill
+    from: Cybernetics
+    level: 5
   - type: fit
     hull: Kronos
-    fit: TDF_KRONOS_ELITE_HYBRID
+    fit: TDF_KRONOS_ELITE
   - type: skills
     from: Kronos
     tier: elite
 
 - name: PALADIN ELITE
   description: >
-    Elite skills Paladin plan, simple.
+    This skill plan only trains the requirements for elite Paladin fits.
   plan:
+  - type: tank
+    from: min
+  - type: skill
+    from: Cybernetics
+    level: 5
   - type: fit
     hull: Paladin
-    fit: TDF_PALLY_ELITE_HYBRID
+    fit: TDF_PALLY_ELITE
   - type: skills
     from: Paladin
     tier: elite
 
-- name: TDF_ONEIROS_STARTER
+- name: ONEIROS STARTER
   description: >
     This skill plan trains you into the ONEIROS_AFFORDABLE fit. Use this to get started in Oni.
   plan:
@@ -210,9 +258,9 @@ plans:
     hull: Oneiros
     fit: TDF_ONI_HQ_STARTER_AFFORDABLE
 
-- name: TDF_ONEIROS_ELITE
+- name: ONEIROS ELITE PATH
   description: >
-    This skill plan trains you into elite Oneiros.
+    This skill plan trains you from starter through to elite Oneiros.
   plan:
   - type: tank
     from: min
@@ -235,12 +283,15 @@ plans:
     from: Oneiros
     tier: elite
 
-- name: TDF_GUARDIAN_BASIC
+- name: GUARDIAN BASIC
   description: >
     This skill plan trains you into the GUARDIAN_BASIC fit. Use this to get started in Guardian.
   plan:
   - type: tank
     from: min
+  - type: skill
+    from: Cybernetics
+    level: 5
   - type: skills
     from: Guardian
     tier: min
@@ -248,15 +299,21 @@ plans:
     hull: Guardian
     fit: TDF_GUARD_HQ_BASIC
 
-- name: TDF_GUARDIAN_ELITE
+- name: GUARDIAN ELITE PATH
   description: >
-    This skill plan trains you into elite Guardian.
+    This skill plan trains you from basic through to elite Guardian.
   plan:
   - type: tank
     from: min
+  - type: skill
+    from: Cybernetics
+    level: 5
   - type: skills
     from: Guardian
     tier: min
+  - type: fit
+    hull: Guardian
+    fit: TDF_GUARD_HQ_BASIC
   - type: fit
     hull: Guardian
     fit: TDF_GUARD_HQ_ADVANCED
@@ -267,24 +324,37 @@ plans:
     from: Guardian
     tier: elite
 
-- name: TDF_NESTOR
+- name: NESTOR ELITE
   description: >
     This skill plan trains you into elite Nestor.
   plan:
+  - type: tank
+    from: min
+  - type: skill
+    from: Cybernetics
+    level: 5
   - type: skills
     from: Nestor
     tier: min
   - type: fit
     hull: Nestor
     fit: TDF_NESTOR_HQ_ELITE_HYBRID
+  - type: fit
+    hull: Nestor
+    fit: TDF_NESTOR_HQ_ELITE_ASCENDANCY
   - type: skills
     from: Nestor
     tier: elite
 
-- name: TDF_EOS
+- name: EOS ELITE
   description: >
     TDF's primary booster. Elite level skills.
   plan:
+  - type: tank
+    from: min
+  - type: skill
+    from: Cybernetics
+    level: 5
   - type: skills
     from: Eos
     tier: min
@@ -295,10 +365,15 @@ plans:
     from: Eos
     tier: elite
 
-- name: TDF_DAMNATION
+- name: DAMNATION ELITE
   description: >
     TDF's secondary booster. Elite level skills.
   plan:
+  - type: tank
+    from: min
+  - type: skill
+    from: Cybernetics
+    level: 5
   - type: skills
     from: Damnation
     tier: min
@@ -309,21 +384,27 @@ plans:
     from: Damnation
     tier: elite
 
-- name: TDF_EVERYTHING
+- name: EVERYTHING GOLD
   description: >
     Train the entire TDF doctrine, including boosters! Not really a serious skill plan. Trains everything to Elite Gold level.
   plan:
   - type: tank
     from: min
+  - type: skill
+    from: Cybernetics
+    level: 5
   - type: fit
     hull: Vindicator
     fit: TDF_VINDI_ELITE_HYBRID
   - type: fit
+    hull: Vindicator
+    fit: TDF_VINDI_ELITE
+  - type: fit
     hull: Kronos
-    fit: TDF_KRONOS_ELITE_HYBRID
+    fit: TDF_KRONOS_ELITE
   - type: fit
     hull: Paladin
-    fit: TDF_PALLY_ELITE_HYBRID
+    fit: TDF_PALLY_ELITE
   - type: fit
     hull: Nightmare
     fit: TDF_NM_ADVANCED
@@ -336,28 +417,9 @@ plans:
   - type: fit
     hull: Nestor
     fit: TDF_NESTOR_HQ_ELITE_HYBRID
-
-  - type: skills
-    from: Vindicator
-    tier: elite
-  - type: skills
-    from: Kronos
-    tier: elite
-  - type: skills
-    from: Paladin
-    tier: elite
-  - type: skills
-    from: Nightmare
-    tier: elite
-  - type: skills
-    from: Oneiros
-    tier: elite
-  - type: skills
-    from: Guardian
-    tier: elite
-  - type: skills
-    from: Nestor
-    tier: elite
+  - type: fit
+    hull: Nestor
+    fit: TDF_NESTOR_HQ_ELITE_ASCENDANCY
 
   - type: skills
     from: Vindicator

--- a/backend/data/skillplan.yaml
+++ b/backend/data/skillplan.yaml
@@ -196,7 +196,7 @@ plans:
 
 - name: VINDICATOR ELITE
   description: >
-    This skill plan only trains the requirements for elite Vindicator fits.
+    This skill plan trains the requirements to allow you to fly any elite Vindicator fit.
   plan:
   - type: tank
     from: min
@@ -215,7 +215,7 @@ plans:
 
 - name: KRONOS ELITE
   description: >
-    This skill plan only trains the requirements for elite Kronos fits.
+    This skill plan trains the requirements to allow you to fly any elite Kronos fit.
   plan:
   - type: tank
     from: min
@@ -231,7 +231,7 @@ plans:
 
 - name: PALADIN ELITE
   description: >
-    This skill plan only trains the requirements for elite Paladin fits.
+    This skill plan trains the requirements to allow you to fly any elite Paladin fit.
   plan:
   - type: tank
     from: min
@@ -247,7 +247,7 @@ plans:
 
 - name: ONEIROS STARTER
   description: >
-    This skill plan trains you into the ONEIROS_AFFORDABLE fit. Use this to get started in Oni.
+    This skill plan trains you into the Oneiros affordable fit. Use this to get started in Oni.
   plan:
   - type: tank
     from: min
@@ -285,7 +285,7 @@ plans:
 
 - name: GUARDIAN BASIC
   description: >
-    This skill plan trains you into the GUARDIAN_BASIC fit. Use this to get started in Guardian.
+    This skill plan trains you into the Guardian basic fit. Use this to get started in Guardian.
   plan:
   - type: tank
     from: min

--- a/frontend/src/Pages/Guide/guides/upgrade/guide.md
+++ b/frontend/src/Pages/Guide/guides/upgrade/guide.md
@@ -46,7 +46,7 @@ TDF works with a tier system. Pilots can be categorized as starter, basic, elite
 - Damage Control Units
 - Multispectrum Coatings
 - Burst Aerator Rigs
-- Resistance Rigs (Thermal, EM, Kinetic, Explosive)
+- Rigs (Thermal, EM, Kinetic, Explosive, Trimark, etc.)
 
 3. Train Starter coloured skills starting with warp drive operation, gunnery skills, MJD etc, leaving drones until last.
 4. Train and get T2 guns and the remainder of the basic fit modules starting with the Core X-Type MWD (this will help greatly with your cap stability) then Magnetic Field Stabilizers & Heat Sinks etc.
@@ -57,16 +57,16 @@ Once you have the basic fit ready to go, continue **training and injecting basic
 
 1. **Upgrade to the advanced fit.** Your skills will already be sufficient, so buy those new modules!
 
-2. **Get your Hybrid set implants**. See TDF-IMPLANT1 mailing list in game for reference. You will need cybernetics 5 trained for the hard wires. The recommended purchase order for the set is:
+2. **Get your mplant set**. See TDF-IMPLANT1 mailing list in game for reference. You will need cybernetics 5 trained for the hard wires. The recommended purchase order for the set is:
 
 - Slot 10 (6% damage Alpha) make sure you get the implant that corresponds to your gun type!
 - Slot 9 (6% damage ROF)
 - Slot 8 (6% capacitor capacity)
 - Slot 7 (6% tracking) Remember to buy the Ogdin's Eye as its usually cheaper on market than the MR-706 from concord LP store.
 - Slot 6 (6% warpspeed)
-- Slots 1-5 (Amulets increase your overall Armor HP and also have stat bonus)
+- Slots 1-5 Amulets OR Ascendancy
 
-Once your set is complete you can upgrade to the \_HYBRID fits on the mailing list, which adds a lot of damage!
+_(You can choose either Hybrid or Warp speed set, both are acceptable, however you must have slots 1-5 Amulets to fly the \_HYBRID fits)_
 
 3. **Train bastion requirements** if you are going for bastion fits.
 
@@ -77,7 +77,7 @@ Once your set is complete you can upgrade to the \_HYBRID fits on the mailing li
 
 ### Elite
 
-Now it's time to get the **elite fit**. You do not need to have every skill at elite level to fly the fit! Go buy those upgrades while still training/injecting the skills.
+Now it's time to get the **elite fit**. You do not need to have every skill at elite level to fly the fit & for the Ascendancy Elite fits you do not need the full implant set to fly the fit, but you will need the implants to get your elite tags. Go buy those upgrades while still training/injecting the skills.
 
 - This is a good time to get **abyssal modules**. [mutaplasmid.space](https://mutaplasmid.space/) is a good website for finding contracts, but remember abyssals must be "better than faction". See the badges section for [Bastion Badge](/guide/badges) requirements for abyssals should you wish to obtain it.
 

--- a/frontend/src/Pages/Guide/guides/upgrade/guide.md
+++ b/frontend/src/Pages/Guide/guides/upgrade/guide.md
@@ -57,7 +57,7 @@ Once you have the basic fit ready to go, continue **training and injecting basic
 
 1. **Upgrade to the advanced fit.** Your skills will already be sufficient, so buy those new modules!
 
-2. **Get your mplant set**. See TDF-IMPLANT1 mailing list in game for reference. You will need cybernetics 5 trained for the hard wires. The recommended purchase order for the set is:
+2. **Get your implant set**. See TDF-IMPLANT1 mailing list in game or see [Fittings page](https://t-d-f.one/fits). You will need cybernetics 5 trained for the hard wires. The recommended purchase order for the set is:
 
 - Slot 10 (6% damage Alpha) make sure you get the implant that corresponds to your gun type!
 - Slot 9 (6% damage ROF)

--- a/frontend/src/Pages/Guide/guides/xup/guide.md
+++ b/frontend/src/Pages/Guide/guides/xup/guide.md
@@ -54,7 +54,7 @@ Fleet anchors are the positions you need to move to, make sure to have them open
 
 **Logi:** Cruisers will orbit a Nestor in the site to help speed tank.
 
-**CQC & Snipers:** You will need to move your ship manually into position using Q to fly around. Open tactical camera with tactical overlay enabled. Hold Q which will draw a line to where you want to go. The first click will set the horizontal plane and the second will set the vertical plane. You can double click quickly to set a simple horizontal plane align. Make sure to check out the [Anchoring guide](/guide/dps)!
+**CQC & Snipers:** You will need to move your ship manually into position using Q to fly around. Open tactical camera with tactical overlay enabled. Hold Q which will draw a line to where you want to go. The first click will set the horizontal plane and the second will set the vertical plane. You can double click quickly to set a simple horizontal plane align. Make sure to check out the [Anchoring guide](/guide/anchoring)!
 
 If you choose to anchor on someone use the Keep at range function to keep you from bumping them. You want to be close so set this to 5000m, but if you are bumping the anchor because you cannot stop in time then increase the distance. You can right click people in your watchlist to keep them at range.
 
@@ -105,4 +105,4 @@ Just ask in fleet chat or over Teamspeak.
 
 ## Keep reading
 
-[Anchoring guide](/guide/dps)
+[Anchoring guide](/guide/anchoring)


### PR DESCRIPTION
Revamped the skill plans to better match the skill requirements of the new doctrine, added some tweaks to priority of skills and tidied the code so it was less cluttered and repetitive. Also re-worked the naming scheme and descriptions to help clarification.