### PR TITLE
Fixed badge page URL

### DIFF
--- a/frontend/src/App/routes.js
+++ b/frontend/src/App/routes.js
@@ -33,7 +33,7 @@ export function Routes() {
       <Route exact path="/guide">
         <GuideIndex />
       </Route>
-      <Route exact path="/badges">
+      <Route exact path="/guide/badges">
         <BadgeIndex />
       </Route>
       <Route exact path="/guide/:guideName">

--- a/frontend/src/Pages/Guide/index.js
+++ b/frontend/src/Pages/Guide/index.js
@@ -134,7 +134,7 @@ export function GuideIndex() {
           The Bastion Module offers a great damage increase, but it has to be used safely. Learn
           how!
         </GuideCard>
-        <GuideCard slug="/badges" name="Information about badges" icon={faIdBadge}>
+        <GuideCard slug="/guide/badges" name="Information about badges" icon={faIdBadge}>
           What are all these badges I see?
         </GuideCard>
         <GuideCard slug="/guide/tips" name="General tips" icon={faInfo}>


### PR DESCRIPTION
Fixes #129 

Brings the badges guide URL back to `/guide/badges` so it is consistent with all the other guide pages, and fixes two links in guides that were causing 404s.

_Attempt 2 - The first attempt was closed as the working branch was based on the wrong branch._