### PR TITLE
Markdown/anchor tags

### DIFF
--- a/frontend/src/Components/Markdown.js
+++ b/frontend/src/Components/Markdown.js
@@ -3,6 +3,7 @@ import remarkGfm from "remark-gfm";
 import { NavLink } from "react-router-dom";
 import { Table, TableHead, TableBody, Cell, CellHead, Row } from "./Table";
 import styled from "styled-components";
+import React, { useEffect } from "react";
 
 const LinkStyle = styled.span`
   a {
@@ -13,6 +14,42 @@ const LinkStyle = styled.span`
 	cursor: pointer;
 	color:  ${(props) => props.theme.colors.highlight.active};
   }  
+`;
+
+const HeadingAnchor = styled.div`
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    display: inline;
+
+    &:hover {
+      a {
+        visibility: visible;
+        opacity: 1;
+      }
+    }
+
+    a {
+      margin-left: 15px;
+      font-size: smaller;
+      text-decoration: none;
+
+      visibility: hidden;
+      opacity: 0;
+      transition: visibility 0.05s, opacity 0.05s linear;
+
+      &:after {
+        content: "#";
+      }
+
+      &:hover {
+        color: ${(props) => props.theme.colors.highlight.active};
+      }
+    }
+  }
 `;
 
 function Link({ href, children, ...props }) {
@@ -31,16 +68,60 @@ function Link({ href, children, ...props }) {
   );
 }
 
-const components = {
-  a: Link,
-  table: Table,
-  thead: TableHead,
-  tbody: TableBody,
-  th: CellHead,
-  td: Cell,
-  tr: Row,
-};
-
 export function Markdown({ ...args }) {
+  const slugs = [];
+
+  const Heading = ({ children, level }) => {
+    const text = children[0];
+
+    let slug =
+      text
+        .replace(/[^a-zA-Z0-9 ]/g, "")
+        ?.replace(/ /g, "-")
+        ?.toLowerCase() ?? "";
+    if (slugs.includes(slug)) {
+      console.warn(
+        `An <h${level}> heading with the id "${slug}" already exists. Headings must be unique, omitting this ID`
+      );
+      slug = null;
+    }
+
+    return (
+      <HeadingAnchor>
+        {React.createElement(
+          `h${level}`,
+          { id: slug },
+          <>
+            {text}
+            <a href={window.location.pathname + "#" + slug} />
+          </>
+        )}
+      </HeadingAnchor>
+    );
+  };
+
+  useEffect(() => {
+    const { hash } = window.location;
+    if (!hash) return; // no hash in URL
+
+    document.getElementById(hash.replace("#", ""))?.scrollIntoView();
+  }, []);
+
+  const components = {
+    h1: Heading,
+    h2: Heading,
+    h3: Heading,
+    h4: Heading,
+    h5: Heading,
+    h6: Heading,
+    a: Link,
+    table: Table,
+    thead: TableHead,
+    tbody: TableBody,
+    th: CellHead,
+    td: Cell,
+    tr: Row,
+  };
+
   return <ReactMarkdown components={components} remarkPlugins={[remarkGfm]} {...args} />;
 }

--- a/frontend/src/Components/Markdown.js
+++ b/frontend/src/Components/Markdown.js
@@ -17,7 +17,6 @@ const LinkStyle = styled.span`
 `;
 
 const HeadingAnchor = styled.div`
-  h1,
   h2,
   h3,
   h4,
@@ -33,7 +32,7 @@ const HeadingAnchor = styled.div`
     }
 
     a {
-      margin-left: 15px;
+      margin-left: 10px;
       font-size: smaller;
       text-decoration: none;
 
@@ -47,6 +46,10 @@ const HeadingAnchor = styled.div`
 
       &:hover {
         color: ${(props) => props.theme.colors.highlight.active};
+      }
+
+      &::selection {
+        background: none;
       }
     }
   }
@@ -69,31 +72,31 @@ function Link({ href, children, ...props }) {
 }
 
 export function Markdown({ ...args }) {
-  const slugs = [];
+  const headings = [];
 
   const Heading = ({ children, level }) => {
     const text = children[0];
 
-    let slug =
-      text
+    let slug = `${text}`
         .replace(/[^a-zA-Z0-9 ]/g, "")
         ?.replace(/ /g, "-")
         ?.toLowerCase() ?? "";
-    if (slugs.includes(slug)) {
-      console.warn(
-        `An <h${level}> heading with the id "${slug}" already exists. Headings must be unique, omitting this ID`
-      );
-      slug = null;
+
+    if (!headings.some(h => h.slug === slug)) {
+      headings.push({
+        text,
+        slug
+      });
     }
 
     return (
       <HeadingAnchor>
         {React.createElement(
           `h${level}`,
-          { id: slug },
+          { id: `${slug}-${headings.length}` },
           <>
             {text}
-            <a href={window.location.pathname + "#" + slug} />
+            <a href={`${window.location.pathname}#${slug}-${headings.length}`}> </a>
           </>
         )}
       </HeadingAnchor>
@@ -108,7 +111,6 @@ export function Markdown({ ...args }) {
   }, []);
 
   const components = {
-    h1: Heading,
     h2: Heading,
     h3: Heading,
     h4: Heading,

--- a/frontend/src/Components/Markdown.js
+++ b/frontend/src/Components/Markdown.js
@@ -77,15 +77,16 @@ export function Markdown({ ...args }) {
   const Heading = ({ children, level }) => {
     const text = children[0];
 
-    let slug = `${text}`
+    let slug =
+      `${text}`
         .replace(/[^a-zA-Z0-9 ]/g, "")
         ?.replace(/ /g, "-")
         ?.toLowerCase() ?? "";
 
-    if (!headings.some(h => h.slug === slug)) {
+    if (!headings.some((h) => h.slug === slug)) {
       headings.push({
         text,
-        slug
+        slug,
       });
     }
 


### PR DESCRIPTION
Add an ID attribute to h2-h6 tags on mark-down pages. I didn't add them to h1 tags as there should only be one per page and it should be at the top. 