### PR TITLE
guardian skill changes

### DIFF
--- a/backend/data/fitnotes.yaml
+++ b/backend/data/fitnotes.yaml
@@ -18,7 +18,7 @@ notes:
       Skill exception: Logistics Cruiser 4
   - name: TDF_GUARD_HQ_BASIC
     description: >
-      Implant Required: EM-806
+      This fit requires the EM-806 Implant & Energy Grid Upgrades 5.
   - name: TDF_GUARD_HQ_ADVANCED
     description: >
       Implant Required: EM-806

--- a/backend/data/skills.yaml
+++ b/backend/data/skills.yaml
@@ -613,7 +613,7 @@ requirements:
     Power Grid Management:
       min: 5
     Energy Grid Upgrades:
-      min: 5
+      min: 4
     Cybernetics:
       min: 5
 

--- a/backend/src/tdf/fitcheck.rs
+++ b/backend/src/tdf/fitcheck.rs
@@ -217,6 +217,13 @@ impl<'a> FitChecker<'a> {
             ));
         }
 
+        if let Some(fit) = self.doctrine_fit {
+            if fit.name.contains("TDF_GUARD_HQ_BASIC") && self.pilot.skills.get(type_id!("Energy Grid Upgrades")) < 5 {
+                self.errors.push("Missing Engineering Skill: Energy Grid Upgrades 5 required".to_string());
+                self.approved = false;
+            }
+        }
+
         if self
             .fit
             .modules


### PR DESCRIPTION
- Set 4 as minimum skill for Energy Grid Upgrades for Guardian
- Added note to basic guardian fit that it requires Energy Upgrades V
- Forbids basic guardian to x up without Energy upgrades V. 

TLDR, only basic guardian requires energy grid upgrades V, people be getting confused, this should fix the issue. 