### PR TITLE
display current sub-page in tab title

### DIFF
--- a/frontend/src/Pages/FC/Announcements.js
+++ b/frontend/src/Pages/FC/Announcements.js
@@ -9,6 +9,7 @@ import Table from "../../Components/DataTable";
 import { Button } from "../../Components/Form";
 import { AuthContext, ToastContext } from "../../contexts";
 import { AddAnnouncement, UpdateAnnouncement } from "./announcements/Modals";
+import { usePageTitle } from "../../Util/title";
 
 const AnnouncementsPage = () => {
   const authContext = React.useContext(AuthContext);
@@ -87,6 +88,7 @@ const View = () => {
     },
   ];
 
+  usePageTitle("Announcements");
   return (
     <>
       <Header>

--- a/frontend/src/Pages/FC/Badges.js
+++ b/frontend/src/Pages/FC/Badges.js
@@ -11,6 +11,7 @@ import { apiCall, useApi } from "../../api";
 import { formatDatetime } from "../../Util/time";
 import BadgeIcon from "../../Components/Badge";
 import { AddBadge, RevokeButton } from "./badges/BadgesPageControls";
+import { usePageTitle } from "../../Util/title";
 
 const BadgesPage = () => {
   const authContext = React.useContext(AuthContext);
@@ -259,6 +260,7 @@ const View = () => {
       row.character.name.toLowerCase().includes(filters?.name.toLowerCase())
   );
 
+  usePageTitle("Specialist Badges");
   return (
     <>
       <Header>

--- a/frontend/src/Pages/FC/Bans.js
+++ b/frontend/src/Pages/FC/Bans.js
@@ -12,6 +12,7 @@ import { FilterComponents, SusspendButton } from "./bans/TableControls";
 import ExpandableRowsComponent from "./bans/ExpandableRows";
 import { AllianceName, CharacterName, CorporationName } from "../../Components/EntityLinks";
 import { formatDate } from "../../Util/time";
+import { usePageTitle } from "../../Util/title";
 
 const Header = styled.div`
   padding-bottom: 10px;
@@ -166,6 +167,7 @@ const View = () => {
     );
   }, [filters, refreshData]); // is data needed?
 
+  usePageTitle("Bans");
   return (
     <>
       <Header>

--- a/frontend/src/Pages/FC/Commanders.js
+++ b/frontend/src/Pages/FC/Commanders.js
@@ -11,6 +11,7 @@ import { AddButton, FilterComponents, RevokeButton } from "./commanders/TableCon
 import CommanderModal from "./commanders/CommanderModal";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUserEdit } from "@fortawesome/free-solid-svg-icons";
+import { usePageTitle } from "../../Util/title";
 
 const Header = styled.div`
   padding-bottom: 10px;
@@ -185,6 +186,7 @@ const View = () => {
     );
   }, [filters, data, refreshData]);
 
+  usePageTitle("Commanders");
   return (
     <>
       <Header>

--- a/frontend/src/Pages/FC/FCMenu.js
+++ b/frontend/src/Pages/FC/FCMenu.js
@@ -16,6 +16,7 @@ import {
   faBullhorn,
   faBan,
 } from "@fortawesome/free-solid-svg-icons";
+import { replaceTitle, parseMarkdownTitle, usePageTitle } from "../../Util/title";
 
 const guideData = {};
 function importAll(r) {
@@ -42,13 +43,18 @@ export function GuideFC() {
   React.useEffect(() => {
     setLoadedData(null);
     if (!(filename in guideData)) return;
+    const title = document.title;
 
     errorToaster(
       toastContext,
       fetch(guideData[filename].default)
         .then((response) => response.text())
-        .then(setLoadedData)
+        .then((data) => {
+          setLoadedData(data);
+          replaceTitle(parseMarkdownTitle(data));
+        })
     );
+    return () => document.title = title;
   }, [toastContext, filename]);
 
   const resolveImage = (name) => {
@@ -100,6 +106,7 @@ function GuideCard({ icon, slug, name, children }) {
 
 export function FCMenu() {
   const authContext = React.useContext(AuthContext);
+  usePageTitle("FC Menu");
   return (
     <>
       <PageTitle>FC Dashboard</PageTitle>

--- a/frontend/src/Pages/FC/Fleet.js
+++ b/frontend/src/Pages/FC/Fleet.js
@@ -7,6 +7,7 @@ import { apiCall, errorToaster, toaster, useApi } from "../../api";
 import { Cell, CellHead, Row, Table, TableBody, TableHead } from "../../Components/Table";
 import { BorderedBox } from "../../Components/NoteBox";
 import _ from "lodash";
+import { usePageTitle } from "../../Util/title";
 
 const marauders = ["Paladin", "Kronos"];
 const logi = ["Nestor", "Guardian", "Oneiros"];
@@ -44,6 +45,7 @@ export function Fleet() {
     }
   }, []);
 
+  usePageTitle("Fleet");
   return (
     <>
       <Buttons>

--- a/frontend/src/Pages/FC/FleetCompHistory.js
+++ b/frontend/src/Pages/FC/FleetCompHistory.js
@@ -7,6 +7,7 @@ import { Cell, CellHead, Row, Table, TableBody, TableHead } from "../../Componen
 import { formatDatetime, formatDuration } from "../../Util/time";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faStar } from "@fortawesome/free-solid-svg-icons";
+import { usePageTitle } from "../../Util/title";
 
 export function FleetCompHistory() {
   const [date, setDate] = React.useState("");
@@ -17,6 +18,7 @@ export function FleetCompHistory() {
 
   const [result] = useApi(parsedDateUnix ? `/api/history/fleet-comp?time=${parsedDateUnix}` : null);
 
+  usePageTitle("Fleet History");
   return (
     <Content>
       <h2>Fleet history lookup</h2>

--- a/frontend/src/Pages/FC/NoteAdd.js
+++ b/frontend/src/Pages/FC/NoteAdd.js
@@ -4,6 +4,7 @@ import { apiCall, errorToaster, useApi } from "../../api";
 import { Button, InputGroup, Textarea } from "../../Components/Form";
 import { PageTitle } from "../../Components/Page";
 import { ToastContext } from "../../contexts";
+import { usePageTitle } from "../../Util/title";
 
 async function saveNote(characterId, note) {
   await apiCall("/api/notes/add", {
@@ -15,6 +16,7 @@ async function saveNote(characterId, note) {
 }
 
 export function NoteAdd() {
+  usePageTitle("Add Note");
   const toastContext = React.useContext(ToastContext);
   const [note, setNote] = React.useState("");
   const [isSubmitting, setIsSubmitting] = React.useState(false);

--- a/frontend/src/Pages/FC/Search.js
+++ b/frontend/src/Pages/FC/Search.js
@@ -6,6 +6,7 @@ import { AuthContext } from "../../contexts";
 import { useQuery } from "../../Util/query";
 import CharacterBadgeModal from "./badges/CharacterBadgeModal";
 import CommanderModal from "./commanders/CommanderModal";
+import { usePageTitle } from "../../Util/title";
 
 export function Search() {
   const authContext = React.useContext(AuthContext);
@@ -19,6 +20,7 @@ export function Search() {
     query && query.length >= 3 ? "/api/search?" + new URLSearchParams({ query }) : null
   );
 
+  usePageTitle("Search");
   return (
     <>
       <div style={{ marginBottom: "1em" }}>

--- a/frontend/src/Pages/FC/Statistics.js
+++ b/frontend/src/Pages/FC/Statistics.js
@@ -4,6 +4,7 @@ import { useApi } from "../../api";
 import { Bar, Line, Doughnut } from "react-chartjs-2";
 import styled, { ThemeContext } from "styled-components";
 import { Row, Col } from "react-awesome-styled-grid";
+import { usePageTitle } from "../../Util/title";
 
 const Graph = styled(Col).attrs({ md: 4 })`
   max-height: 350px;
@@ -307,6 +308,7 @@ function TimeSpentByHull28d({ data }) {
 }
 
 export function Statistics() {
+  usePageTitle("Statistics");
   const [statsData] = useApi("/api/stats");
 
   if (!statsData) {

--- a/frontend/src/Pages/Fits/index.js
+++ b/frontend/src/Pages/Fits/index.js
@@ -3,6 +3,7 @@ import { InputGroup, Button, Buttons } from "../../Components/Form";
 import { Fitout, ImplantOut } from "./FittingSortDisplay";
 import { PageTitle } from "../../Components/Page";
 import { useLocation, useHistory } from "react-router-dom";
+import { usePageTitle } from "../../Util/title";
 
 export function Fits() {
   const queryParams = new URLSearchParams(useLocation().search);
@@ -19,6 +20,7 @@ export function Fits() {
 }
 
 function FitsDisplay({ tier, setTier = null }) {
+  usePageTitle(`${tier} Fits`);
   const [fitData] = useApi(`/api/fittings`);
   if (fitData === null) {
     return <em>Loading fits...</em>;

--- a/frontend/src/Pages/Guide/Badges.js
+++ b/frontend/src/Pages/Guide/Badges.js
@@ -8,6 +8,7 @@ import { NavButton, InputGroup } from "../../Components/Form";
 import { InfoNote } from "../../Components/NoteBox";
 
 import { BadgeDOM, BadgeModal } from "../../Components/Badge";
+import { usePageTitle } from "../../Util/title";
 
 const BadgeDisplay = styled.div`
   display: flex;
@@ -59,6 +60,7 @@ function BadgeButton({ name, img, children }) {
 }
 
 export function BadgeData() {
+  usePageTitle("Badges");
   return (
     <>
       <Content style={{ marginBottom: "2em" }}>

--- a/frontend/src/Pages/Guide/index.js
+++ b/frontend/src/Pages/Guide/index.js
@@ -22,6 +22,7 @@ import {
   faUserGraduate,
   faUsers,
 } from "@fortawesome/free-solid-svg-icons";
+import { replaceTitle, parseMarkdownTitle, usePageTitle } from "../../Util/title";
 
 const guideData = {};
 function importAll(r) {
@@ -43,13 +44,18 @@ export function Guide() {
   React.useEffect(() => {
     setLoadedData(null);
     if (!(filename in guideData)) return;
+    let title = document.title;
 
     errorToaster(
       toastContext,
       fetch(guideData[filename].default)
         .then((response) => response.text())
-        .then(setLoadedData)
+        .then((data) => {
+          setLoadedData(data);
+          replaceTitle(parseMarkdownTitle(data));
+        })
     );
+    return () => document.title = title;
   }, [toastContext, filename]);
 
   const resolveImage = (name) => {
@@ -104,6 +110,7 @@ function GuideCard({ icon, slug, name, children }) {
 }
 
 export function GuideIndex() {
+  usePageTitle("Guides");
   return (
     <>
       <PageTitle>Guides</PageTitle>

--- a/frontend/src/Pages/ISKh.js
+++ b/frontend/src/Pages/ISKh.js
@@ -11,6 +11,7 @@ import { formatDatetime, formatDuration } from "../Util/time";
 import { formatNumber } from "../Util/number";
 import _ from "lodash";
 import styled from "styled-components";
+import { usePageTitle } from "../Util/title";
 
 function encodeArray(numbers) {
   var buffer = [];
@@ -208,6 +209,7 @@ export function ISKhCalc() {
   const parsed = parseWallet(input);
   const dataStr = parsed ? encodeData(parsed) : null;
 
+  usePageTitle("ISK/h");
   return (
     <>
       <PageTitle>ISK/h calculator</PageTitle>

--- a/frontend/src/Pages/Legal.js
+++ b/frontend/src/Pages/Legal.js
@@ -1,6 +1,8 @@
 import { Content } from "../Components/Page";
+import { usePageTitle } from "../Util/title";
 
 export function Legal() {
+  usePageTitle("Legal Notice");
   return (
     <Content>
       <h2>CCP Copyright Notice</h2>

--- a/frontend/src/Pages/Pilot/index.js
+++ b/frontend/src/Pages/Pilot/index.js
@@ -22,6 +22,7 @@ import { Row, Col } from "react-awesome-styled-grid";
 import _ from "lodash";
 import CommanderModal from "../FC/commanders/CommanderModal";
 import { AccountBannedBanner } from "../FC/bans/AccountBanned";
+import { usePageTitle } from "../../Util/title";
 
 const FilterButtons = styled.span`
   font-size: 0.75em;
@@ -79,6 +80,7 @@ function PilotDisplay({ authContext }) {
     authContext.access["notes-view"] ? `/api/notes?character_id=${characterId}` : null
   );
 
+  usePageTitle("Pilot");
   return (
     <>
       { authContext.access["bans-manage"] && <AccountBannedBanner bans={banHistory} /> }

--- a/frontend/src/Pages/Skills/Plans.js
+++ b/frontend/src/Pages/Skills/Plans.js
@@ -15,6 +15,7 @@ import styled from "styled-components";
 import { useQuery } from "../../Util/query";
 import { Card, CardMargin, CardArray } from "../../Components/Card";
 import { NavLink } from "react-router-dom";
+import { titleCase, usePageTitle } from "../../Util/title";
 
 export function Plans() {
   const authContext = React.useContext(AuthContext);
@@ -88,6 +89,7 @@ function ShowPlan({ plan, mySkills }) {
     );
   });
 
+  usePageTitle(titleCase(plan.source.name));
   return (
     <GridRow>
       <Col xs={4} md={4}>
@@ -170,6 +172,7 @@ const CardImages = styled.div`
 `;
 
 function PlanList({ plans, mySkills }) {
+  usePageTitle("Skill Plans");
   return (
     <>
       <PageTitle>Skill plans</PageTitle>

--- a/frontend/src/Pages/Skills/Skills.js
+++ b/frontend/src/Pages/Skills/Skills.js
@@ -3,6 +3,7 @@ import { AuthContext } from "../../contexts";
 import { useLocation, useHistory } from "react-router-dom";
 import { PageTitle, Content } from "../../Components/Page";
 import { useApi } from "../../api";
+import { usePageTitle } from "../../Util/title";
 
 import { SkillDisplay } from "../../Components/SkillDisplay";
 
@@ -38,6 +39,7 @@ function SkillsAuth({ authContext }) {
     });
   };
 
+  usePageTitle(`${ship} Skills`);
   return (
     <>
       <PageTitle>{basicInfo ? `Skills for ${basicInfo.name}` : "Skills"}</PageTitle>

--- a/frontend/src/Pages/Waitlist/index.js
+++ b/frontend/src/Pages/Waitlist/index.js
@@ -15,6 +15,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faColumns } from "@fortawesome/free-solid-svg-icons";
 import _ from "lodash";
 import { useQuery } from "../../Util/query";
+import { usePageTitle } from "../../Util/title";
 
 function coalesceCalls(func, wait) {
   var nextCall = null;
@@ -128,6 +129,8 @@ export function Waitlist() {
   const [waitlistData, refreshWaitlist] = useWaitlist(waitlistId);
   const fleetComposition = useFleetComposition();
   const displayMode = query.mode || "columns";
+
+  usePageTitle("Waitlist");
 
   const setDisplayMode = (newMode) => {
     setQuery("mode", newMode);

--- a/frontend/src/Pages/Xup/index.js
+++ b/frontend/src/Pages/Xup/index.js
@@ -11,6 +11,7 @@ import { Box } from "../../Components/Box";
 import { Modal } from "../../Components/Modal";
 
 import howToX from "./howtox.png";
+import { usePageTitle } from "../../Util/title";
 
 const exampleFit = String.raw`
 [Vindicator, Vindicator]
@@ -72,6 +73,7 @@ async function xUp({ character, eft, toastContext, waitlist_id, alt }) {
 }
 
 export function Xup() {
+  usePageTitle("X-up");
   const toastContext = React.useContext(ToastContext);
   const authContext = React.useContext(AuthContext);
   const queryParams = new URLSearchParams(useLocation().search);

--- a/frontend/src/Util/title.js
+++ b/frontend/src/Util/title.js
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+
+export function usePageTitle(suffix) {
+  useEffect(() => {
+    let title = document.title;
+    replaceTitle(suffix);
+    return () => document.title = title;
+  });
+}
+
+export function replaceTitle(suffix) {
+  document.title = `TDF: ${suffix}`;
+}
+
+export function parseMarkdownTitle(data) {
+  const heading = data.split("\n")[0];
+  return heading.substring(heading.indexOf(" "));
+}
+
+export function titleCase(title) {
+  return (
+    title.split(" ")
+      .map((word) => word[0].toUpperCase() + word.substr(1).toLowerCase())
+      .join(" ")
+  );
+}


### PR DESCRIPTION
All the different pages have the same title. I like to have a lot of tabs open, so this is confusing.

Before:
![tab tree with identical titles](https://user-images.githubusercontent.com/6196356/198892624-0a27dbd1-880a-4b2b-ac9a-db47c8a79299.png)

After:
![same tab tree, but titles contain the page name](https://user-images.githubusercontent.com/6196356/198892635-b449a97e-8ed4-42c3-83f2-3ea301948df2.png)

I'm not quite sure if appending the page names to the title is good. Maybe we should prepend instead? That's how Wikipedia does it.

Also the titles are quite long this way, how about reserving the full `TDF: The Ditanian Fleet` for the landing page and shortening everything else to `TDF – ${pageName}` or  `${pageName} – TDF`?

What do you think about this?